### PR TITLE
Omnipay v3 compatibility and removed unecessary var_dump in a test. (…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,11 @@
 language: php
 
 php:
-  - 5.4
-  - 5.5
   - 5.6
   - 7.0
   - 7.1
-
-matrix:
-  include:
-    - php: 5.3
-      dist: precise
+  - 7.2
+  - 7.3
       
 before_script:
   - composer install -n --dev --prefer-source

--- a/composer.json
+++ b/composer.json
@@ -26,10 +26,11 @@
         "psr-4": { "Omnipay\\Netaxept\\" : "src/" }
     },
     "require": {
-        "omnipay/common": "~2.0"
+        "omnipay/common": "~3.0"
     },
     "require-dev": {
-        "omnipay/tests": "~2.0"
+        "omnipay/tests": "~3.0",
+        "squizlabs/php_codesniffer": "^3"
     },
     "extra": {
         "branch-alias": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -14,9 +14,6 @@
             <directory>./tests/</directory>
         </testsuite>
     </testsuites>
-    <listeners>
-        <listener class="Mockery\Adapter\Phpunit\TestListener" file="vendor/mockery/mockery/library/Mockery/Adapter/Phpunit/TestListener.php" />
-    </listeners>
     <filter>
         <whitelist>
             <directory>./src</directory>

--- a/src/Message/AnnulRequest.php
+++ b/src/Message/AnnulRequest.php
@@ -31,8 +31,8 @@ class AnnulRequest extends PurchaseRequest
     public function sendData($data)
     {
         $url = $this->getEndpoint().'/Netaxept/Process.aspx?';
-        $httpResponse = $this->httpClient->get($url.http_build_query($data))->send();
+        $httpResponse = $this->httpClient->request('GET', $url.http_build_query($data));
 
-        return $this->response = new Response($this, $httpResponse->xml());
+        return $this->response = new Response($this, simplexml_load_string($httpResponse->getBody()->getContents()));
     }
 }

--- a/src/Message/CaptureRequest.php
+++ b/src/Message/CaptureRequest.php
@@ -30,8 +30,8 @@ class CaptureRequest extends PurchaseRequest
     public function sendData($data)
     {
         $url = $this->getEndpoint().'/Netaxept/Process.aspx?';
-        $httpResponse = $this->httpClient->get($url.http_build_query($data))->send();
+        $httpResponse = $this->httpClient->request('GET', $url.http_build_query($data));
 
-        return $this->response = new Response($this, $httpResponse->xml());
+        return $this->response = new Response($this, simplexml_load_string($httpResponse->getBody()->getContents()));
     }
 }

--- a/src/Message/CompletePurchaseRequest.php
+++ b/src/Message/CompletePurchaseRequest.php
@@ -32,8 +32,8 @@ class CompletePurchaseRequest extends PurchaseRequest
         }
 
         $url = $this->getEndpoint().'/Netaxept/Process.aspx?';
-        $httpResponse = $this->httpClient->get($url.http_build_query($data))->send();
+        $httpResponse = $this->httpClient->request('GET', $url.http_build_query($data));
 
-        return $this->response = new Response($this, $httpResponse->xml());
+        return $this->response = new Response($this, simplexml_load_string($httpResponse->getBody()->getContents()));
     }
 }

--- a/src/Message/CreditRequest.php
+++ b/src/Message/CreditRequest.php
@@ -31,8 +31,8 @@ class CreditRequest extends PurchaseRequest
     public function sendData($data)
     {
         $url = $this->getEndpoint().'/Netaxept/Process.aspx?';
-        $httpResponse = $this->httpClient->get($url.http_build_query($data))->send();
+        $httpResponse = $this->httpClient->request('GET', $url.http_build_query($data));
 
-        return $this->response = new Response($this, $httpResponse->xml());
+        return $this->response = new Response($this, simplexml_load_string($httpResponse->getBody()->getContents()));
     }
 }

--- a/src/Message/PurchaseRequest.php
+++ b/src/Message/PurchaseRequest.php
@@ -74,9 +74,9 @@ class PurchaseRequest extends AbstractRequest
     public function sendData($data)
     {
         $url = $this->getEndpoint().'/Netaxept/Register.aspx?';
-        $httpResponse = $this->httpClient->get($url.http_build_query($data))->send();
+        $httpResponse = $this->httpClient->request('GET', $url.http_build_query($data));
 
-        return $this->response = new Response($this, $httpResponse->xml());
+        return $this->response = new Response($this, simplexml_load_string($httpResponse->getBody()->getContents()));
     }
 
     public function getEndpoint()

--- a/tests/GatewayTest.php
+++ b/tests/GatewayTest.php
@@ -100,8 +100,6 @@ class GatewayTest extends GatewayTestCase
         $this->assertFalse($response->isRedirect());
         $this->assertNull($response->getTransactionReference());
 
-        var_dump($response->getMessage());
-
         $this->assertSame('Unable to find transaction', $response->getMessage());
     }
 

--- a/tests/Message/ResponseTest.php
+++ b/tests/Message/ResponseTest.php
@@ -9,7 +9,8 @@ class ResponseTest extends TestCase
     public function testPurchaseSuccess()
     {
         $httpResponse = $this->getMockHttpResponse('PurchaseSuccess.txt');
-        $response = new Response($this->getMockRequest(), $httpResponse->xml());
+        $xml = simplexml_load_string($httpResponse->getBody()->getContents());
+        $response = new Response($this->getMockRequest(), $xml);
 
         $this->assertFalse($response->isSuccessful());
         $this->assertTrue($response->isRedirect());
@@ -20,7 +21,8 @@ class ResponseTest extends TestCase
     public function testPurchaseFailure()
     {
         $httpResponse = $this->getMockHttpResponse('PurchaseFailure.txt');
-        $response = new Response($this->getMockRequest(), $httpResponse->xml());
+        $xml = simplexml_load_string($httpResponse->getBody()->getContents());
+        $response = new Response($this->getMockRequest(), $xml);
 
         $this->assertFalse($response->isSuccessful());
         $this->assertFalse($response->isRedirect());
@@ -33,7 +35,8 @@ class ResponseTest extends TestCase
     public function testCompletePurchaseSuccess()
     {
         $httpResponse = $this->getMockHttpResponse('CompletePurchaseSuccess.txt');
-        $response = new Response($this->getMockRequest(), $httpResponse->xml());
+        $xml = simplexml_load_string($httpResponse->getBody()->getContents());
+        $response = new Response($this->getMockRequest(), $xml);
 
         $this->assertTrue($response->isSuccessful());
         $this->assertFalse($response->isRedirect());
@@ -44,7 +47,8 @@ class ResponseTest extends TestCase
     public function testCompletePurchaseFailure()
     {
         $httpResponse = $this->getMockHttpResponse('CompletePurchaseFailure.txt');
-        $response = new Response($this->getMockRequest(), $httpResponse->xml());
+        $xml = simplexml_load_string($httpResponse->getBody()->getContents());
+        $response = new Response($this->getMockRequest(), $xml);
 
         $this->assertFalse($response->isSuccessful());
         $this->assertFalse($response->isRedirect());
@@ -55,7 +59,8 @@ class ResponseTest extends TestCase
     public function testCaptureSuccess()
     {
         $httpResponse = $this->getMockHttpResponse('CaptureSuccess.txt');
-        $response = new Response($this->getMockRequest(), $httpResponse->xml());
+        $xml = simplexml_load_string($httpResponse->getBody()->getContents());
+        $response = new Response($this->getMockRequest(), $xml);
 
         $this->assertTrue($response->isSuccessful());
         $this->assertFalse($response->isRedirect());
@@ -66,7 +71,8 @@ class ResponseTest extends TestCase
     public function testCaptureFailure()
     {
         $httpResponse = $this->getMockHttpResponse('CaptureFailure.txt');
-        $response = new Response($this->getMockRequest(), $httpResponse->xml());
+        $xml = simplexml_load_string($httpResponse->getBody()->getContents());
+        $response = new Response($this->getMockRequest(), $xml);
 
         $this->assertFalse($response->isSuccessful());
         $this->assertFalse($response->isRedirect());
@@ -77,7 +83,8 @@ class ResponseTest extends TestCase
     public function testAnnulSuccess()
     {
         $httpResponse = $this->getMockHttpResponse('AnnulSuccess.txt');
-        $response = new Response($this->getMockRequest(), $httpResponse->xml());
+        $xml = simplexml_load_string($httpResponse->getBody()->getContents());
+        $response = new Response($this->getMockRequest(), $xml);
 
         $this->assertTrue($response->isSuccessful());
         $this->assertFalse($response->isRedirect());
@@ -88,7 +95,8 @@ class ResponseTest extends TestCase
     public function testAnnullFailure()
     {
         $httpResponse = $this->getMockHttpResponse('AnnulFailure.txt');
-        $response = new Response($this->getMockRequest(), $httpResponse->xml());
+        $xml = simplexml_load_string($httpResponse->getBody()->getContents());
+        $response = new Response($this->getMockRequest(), $xml);
 
         $this->assertFalse($response->isSuccessful());
         $this->assertFalse($response->isRedirect());
@@ -99,7 +107,8 @@ class ResponseTest extends TestCase
     public function testCreditSuccess()
     {
         $httpResponse = $this->getMockHttpResponse('CreditSuccess.txt');
-        $response = new Response($this->getMockRequest(), $httpResponse->xml());
+        $xml = simplexml_load_string($httpResponse->getBody()->getContents());
+        $response = new Response($this->getMockRequest(), $xml);
 
         $this->assertTrue($response->isSuccessful());
         $this->assertFalse($response->isRedirect());
@@ -110,7 +119,8 @@ class ResponseTest extends TestCase
     public function testCreditFailure()
     {
         $httpResponse = $this->getMockHttpResponse('CreditFailure.txt');
-        $response = new Response($this->getMockRequest(), $httpResponse->xml());
+        $xml = simplexml_load_string($httpResponse->getBody()->getContents());
+        $response = new Response($this->getMockRequest(), $xml);
 
         $this->assertFalse($response->isSuccessful());
         $this->assertFalse($response->isRedirect());


### PR DESCRIPTION
…#13)

* Omnipay v3 compatibility and removed unecessary var_dump in a test.

* Adding php_codesniffer

* Remove PHP 5.4 & 5.5 from travis.yml.

* Removing PHP 5.3 and adding 7.2 & 7.3.